### PR TITLE
feat: php7 support (required by SF5)

### DIFF
--- a/Error/Exception/FormErrorException.php
+++ b/Error/Exception/FormErrorException.php
@@ -11,7 +11,7 @@ namespace Tbbc\RestUtilBundle\Error\Exception;
 
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @author Boris Guéry <guery.b@gmail.com>
@@ -25,7 +25,7 @@ class FormErrorException extends \InvalidArgumentException
 
     public function __construct(FormInterface $form, TranslatorInterface $translator = null,
                                 $message = 'An error has occurred while processing your request, make sure your data are valid',
-                                $code = 400, \Exception $previous = null)
+                                $code = 400, \Throwable $previous = null)
     {
         $this->translator = $translator;
         $this->buildErrorsTree($form);

--- a/Error/Factory/FormErrorFactory.php
+++ b/Error/Factory/FormErrorFactory.php
@@ -30,7 +30,7 @@ class FormErrorFactory implements ErrorFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function createError(\Exception $exception, ExceptionMappingInterface $mapping)
+    public function createError(\Throwable $exception, ExceptionMappingInterface $mapping)
     {
         if (!$this->supportsException($exception)) {
             return null;
@@ -54,7 +54,7 @@ class FormErrorFactory implements ErrorFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsException(\Exception $exception)
+    public function supportsException(\Throwable $exception)
     {
         return $exception instanceof FormErrorException;
     }

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ class CustomErrorFactory implements ErrorFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function createError(\Exception $exception, ExceptionMappingInterface $mapping)
+    public function createError(\Throwable $exception, ExceptionMappingInterface $mapping)
     {
         if (!$this->supportsException($exception)) {
             return null;
@@ -237,7 +237,7 @@ class CustomErrorFactory implements ErrorFactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function supportsException(\Exception $exception)
+    public function supportsException(\Throwable $exception)
     {
         return $exception instanceof CustomException;
     }

--- a/Tests/DependencyInjection/Compiler/ErrorFactoryCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ErrorFactoryCompilerPassTest.php
@@ -150,7 +150,7 @@ class CustomErrorFactory implements ErrorFactoryInterface
         return 'custom';
     }
 
-    public function createError(\Exception $exception, ExceptionMappingInterface $mapping)
+    public function createError(\Throwable $exception, ExceptionMappingInterface $mapping)
     {
         return new Error($mapping->getHttpStatusCode(), $mapping->getErrorCode(), $mapping->getErrorMessage());
     }


### PR DESCRIPTION
En SF5 on gère les exceptions avec l'interface throwable (introduite en php7)